### PR TITLE
Prevent use runuser with same user

### DIFF
--- a/src/RunServerListener.php
+++ b/src/RunServerListener.php
@@ -81,7 +81,7 @@ class RunServerListener implements EventSubscriberInterface
 
         $cmd = 'php -S ' . self::$host .':' . self::$port . ' -t ' . $script;
 
-        if ($this->runAs) {
+        if ($this->runAs && get_current_user() !== $this->runAs) {
             $cmd = 'runuser -u ' . $this->runAs . ' -- ' . $cmd;
         }
 


### PR DESCRIPTION
To use the command runuser isn necessary to be a sudoers user. If the current user is the same of specified by runas, is unecessary to use the command runuser.